### PR TITLE
Cleanup Makefile to compile in build dir

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,8 @@ defmodule NervesDht.Mixfile do
      description: description(),
      package: package(),
      compilers: [:elixir_make] ++ Mix.compilers,
+     make_targets: ["all"],
+     make_clean: ["clean"],
      build_embedded: true,
      start_permanent: Mix.env == :prod,
      deps: deps()]


### PR DESCRIPTION
Fixes https://github.com/esdrasedu/nerves_dht/issues/3

The current Makefile creates the object files in the src dir. This is problematic when you might be switching between targets, pulling new nerves systems, or automa
tically fetching deps (*cough cough* _vscode_)

This changes that to build within the `_build` directory. Specifically, it will use the `MIX_COMPILE_PATH` which will separate build dirs by target and env. Likewise, other parts of the Makefile are adjusted to support this new flow (`clean`, etc).

It also fixes compiling when running `mix compile` with a target of `host`.